### PR TITLE
Add mandatory attributes for Generic Nack command

### DIFF
--- a/smpplib/command.py
+++ b/smpplib/command.py
@@ -566,7 +566,8 @@ class DataSMResp(Command):
 
 class GenericNAck(Command):
     """General Negative Acknowledgement class"""
-
+    params = {}
+    params_order = ()
     _defs = []
 
     def __init__(self, command, **kwargs):

--- a/smpplib/command.py
+++ b/smpplib/command.py
@@ -566,6 +566,7 @@ class DataSMResp(Command):
 
 class GenericNAck(Command):
     """General Negative Acknowledgement class"""
+
     params = {}
     params_order = ()
     _defs = []


### PR DESCRIPTION
Add mandatory attributes, as the following errors with
 `AttributeError: 'GenericNAck' object has no attribute 'params_order'`:

                p = smpp.make_pdu('generic_nack')
                self.client.send_pdu(p)